### PR TITLE
fix: multi device bluetooth support

### DIFF
--- a/home/packages/default.nix
+++ b/home/packages/default.nix
@@ -22,6 +22,7 @@ in {
       inotify-tools
       fd
       mlocate
+      bluetui
       bluetuith
       brightnessctl
       pamixer

--- a/modules/configuration.nix
+++ b/modules/configuration.nix
@@ -138,6 +138,11 @@
       enable = true;
       powerOnBoot = true;
       hsphfpd.enable = true;
+      settings = {
+        General = {
+          MultiProfile = "multiple";
+        };
+      };
     };
     graphics = lib.mkMerge [
       {

--- a/modules/configuration.nix
+++ b/modules/configuration.nix
@@ -134,6 +134,7 @@
 
   # Enable bluetooth, enable pulseaudio, enable opengl (for Wayland)
   hardware = {
+    keyboard.qmk.enable = true;
     bluetooth = {
       enable = true;
       powerOnBoot = true;
@@ -141,6 +142,10 @@
       settings = {
         General = {
           MultiProfile = "multiple";
+          FastConnectable = true;
+          ReconnectAttempts = 0;
+          ReconnectIntervals = "1, 2, 3";
+          ReverseServiceDiscovery = true;
         };
       };
     };


### PR DESCRIPTION
By default multiple devices are not supported to be connected to the same computer in linux. 

This simply changes a single flag inside the bluetooth main config file: `/etc/bluetooth/main.conf`

This should not be capable of breaking anything else but the bluetooth module. 