### PR TITLE
fix: removed the path check inside the declarative password

### DIFF
--- a/modules/declarative-password/default.nix
+++ b/modules/declarative-password/default.nix
@@ -7,18 +7,16 @@
 }:
 with lib; let
   cfg = config.modules.declarative-password;
-  path = config.age.secrets.user-password.path;
-  path_exist = pathExists path;
 in {
   options.modules.declarative-password = {enable = mkEnableOption "declarative-password";};
   config = mkMerge [
-    (mkIf (cfg.enable && path_exist) {
+    (mkIf (cfg.enable) {
       users.mutableUsers = false;
 
       users.users.${user}.hashedPasswordFile = path;
     })
-    (mkIf (cfg.enable == false || path_exist == false) {
-      users.users.${user}.initialPassword = "root";
+    (mkIf (cfg.enable == false) {
+      users.users.${user}.password = "root";
     })
   ];
 }


### PR DESCRIPTION
This is an easy fix to a change that I merged before. The change was just to check if the agefiles was decrypted correctly before enabling declarative password, however that did not work. This is more of a rollback than a feature.