### PR TITLE
hypr-zoom

### DIFF
--- a/home/hyprland/default.nix
+++ b/home/hyprland/default.nix
@@ -76,6 +76,7 @@ in {
       hyprkool
       hyprpicker
       grimblast
+      hypr-zoom
     ];
 
     wayland.windowManager.hyprland = {

--- a/home/hyprland/hyprland.nix
+++ b/home/hyprland/hyprland.nix
@@ -136,6 +136,8 @@ in {
       "CTRL SUPER SHIFT,F,exec, hyprctl dispatch workspaceopt allfloat"
       "$mod,Tab,exec,hyprkool toggle-overview"
       "CTRL SHIFT,Escape,exec,${terminal} btop"
+      "$smod,z,exec,hypr-zoom -easing=OutBack -easingOut=OutExpo"
+      ", mouse:275, exec, hypr-zoom -easing=OutBack -easingOut=OutExpo"
       # Applications
       "$mod,T,exec,${terminal}"
       "$mod,B,exec,${browser}"

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -6,4 +6,5 @@ _final: prev: {
   vimix-hyprcursor = prev.callPackage ./vimix-hyprcursor.nix {};
   sddm-glassy = prev.callPackage ./sddm-glassy {};
   regreet = prev.callPackage ./regreet.nix {};
+  hypr-zoom = prev.callPackage ./hypr-zoom.nix {};
 }

--- a/overlays/hypr-zoom.nix
+++ b/overlays/hypr-zoom.nix
@@ -1,0 +1,23 @@
+{
+  buildGoModule,
+  fetchFromGitHub,
+}:
+buildGoModule rec {
+  pname = "hypr-zoom";
+  version = "v0.0.3";
+
+  src = fetchFromGitHub {
+    owner = "FShou";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-/5nC4iLcDJ+UODLpzuVitQTFdBZtz75ep73RSN37hHE=";
+  };
+
+  vendorHash = "sha256-BCx2hKi6U/MPJlwAmnM4/stiolhYkakpe4EN3e5r6L4=";
+
+  meta = {
+    description = "Smoothly Animated Zoom for Hyprland";
+    homepage = "https://github.com/FShou/hypr-zoom";
+    mainProgram = pname;
+  };
+}


### PR DESCRIPTION
fixes #38

Add a keybind to zoom to mouse and adds the functionality to zoom using the go application [hypr-zoom](github.com/FShou/hypr-zoom/).